### PR TITLE
Track fetch output so scheduled runs persist data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ CLAUDE.md
 # Downloaded data (keep directory)
 downloaded/*
 !downloaded/.gitkeep
-
-# Processed data (keep directory)
-processed/*
-!processed/.gitkeep


### PR DESCRIPTION
Scheduled fetch writes to `processed/` but `.gitignore` discards it, so runs downloaded data daily and committed nothing — and the resulting inactivity auto-disabled the crons. Removed the ignore block so fetch output persists.